### PR TITLE
Do not hardcode workspace name in remote state configurations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,20 +24,25 @@ jobs:
       - uses: actions/setup-go@v2-beta
         with:
           go-version: '1.13.8'
+      - name: Store installed Python version
+        run: |
+          echo "::set-env name=PY_VERSION::"\
+          "$(python -c "import platform;print(platform.python_version())")"
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
           path: ${{ env.PIP_CACHE_DIR }}
-          key: "${{ runner.os }}-pip-test-\
+          key: "${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}"
           restore-keys: |
+            ${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-
             ${{ runner.os }}-pip-test-
             ${{ runner.os }}-pip-
       - name: Cache pre-commit hooks
         uses: actions/cache@v1
         with:
           path: ${{ env.PRE_COMMIT_CACHE_DIR }}
-          key: "${{ runner.os }}-pre-commit-\
+          key: "${{ runner.os }}-pre-commit-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
       - name: Cache curl downloads
         uses: actions/cache@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.mypy_cache
 __pycache__
 .python-version
 .terraform

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.0.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -74,7 +74,7 @@ repos:
     rev: v4.2.0
     hooks:
       - id: ansible-lint
-        # files: molecule/default/playbook.yml
+      # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
     rev: v1.12.0
     hooks:
@@ -88,3 +88,7 @@ repos:
     rev: 1.19.1
     hooks:
       - id: prettier
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.761
+    hooks:
+      - id: mypy

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -16,5 +16,5 @@ data "terraform_remote_state" "networking" {
     key            = "cool-sharedservices-networking/terraform.tfstate"
   }
 
-  workspace = "production"
+  workspace = terraform.workspace
 }


### PR DESCRIPTION
## 🗣 Description

The workspace name in remote state configurations was previously hardcoded to "production".  This PR changes the code to instead use `terraform.workspace`, so that the workspace name changes as we switch between the production and staging environments.

I also went ahead and took the opportunity to pull in the latest from the upstream [cisagov/skeleton-tf-module](https://github.com/cisagov/skeleton-tf-module) skeleton.

## 💭 Motivation and Context

We need to be able to switch as seamlessly as possible between the production and staging environments.  The more manual foo that is required the more likely that we make a mistake and damage production.

## 🧪 Testing

These changes were successfully deployed to staging.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
