### PR TITLE
Modify to work with new account names and get rid of public IPs and DNS entries

### DIFF
--- a/caller_identity.tf
+++ b/caller_identity.tf
@@ -1,0 +1,6 @@
+# ------------------------------------------------------------------------------
+# We can get the account ID of the Shared Services account from the
+# provider's caller identity.
+# ------------------------------------------------------------------------------
+data "aws_caller_identity" "sharedservices" {
+}

--- a/freeipa.tf
+++ b/freeipa.tf
@@ -3,6 +3,31 @@
 #-------------------------------------------------------------------------------
 
 locals {
+  # Get Shared Services account ID from the default provider
+  this_account_id = data.aws_caller_identity.sharedservices.account_id
+
+  # Look up Shared Services account name from AWS organizations
+  # provider
+  this_account_name = [
+    for account in data.aws_organizations_organization.cool.accounts :
+    account.name
+    if account.id == local.this_account_id
+  ][0]
+
+  # Determine Shared Services account type based on account name.
+  #
+  # The account name format is "ACCOUNT_NAME (ACCOUNT_TYPE)" - for
+  # example, "Shared Services (Production)".
+  this_account_type = length(regexall("\\(([^()]*)\\)", local.this_account_name)) == 1 ? regex("\\(([^()]*)\\)", local.this_account_name)[0] : "Unknown"
+
+  # Determine the ID of the corresponding Images account
+  images_account_id = [
+    for account in data.aws_organizations_organization.cool.accounts :
+    account.id
+    if account.name == "Images (${local.this_account_type})"
+  ][0]
+
+  # The subnets where the master and two replicas are to be placed
   master_subnet_cidr   = keys(data.terraform_remote_state.networking.outputs.private_subnets)[0]
   replica1_subnet_cidr = keys(data.terraform_remote_state.networking.outputs.private_subnets)[1]
   replica2_subnet_cidr = keys(data.terraform_remote_state.networking.outputs.private_subnets)[2]
@@ -17,8 +42,8 @@ module "ipa_master" {
   }
 
   admin_pw                    = var.admin_pw
-  ami_owner_account_id        = "207871073513" # The COOL Images account
-  associate_public_ip_address = true
+  ami_owner_account_id        = local.images_account_id
+  associate_public_ip_address = false
   cert_bucket_name            = var.cert_bucket_name
   cert_pw                     = var.master_cert_pw
   cert_read_role_arn          = module.certreadrole_ipa_master.role.arn
@@ -43,8 +68,8 @@ module "ipa_replica1" {
   }
 
   admin_pw                    = var.admin_pw
-  ami_owner_account_id        = "207871073513" # The COOL Images account
-  associate_public_ip_address = true
+  ami_owner_account_id        = local.images_account_id
+  associate_public_ip_address = false
   cert_bucket_name            = var.cert_bucket_name
   cert_pw                     = var.replica1_cert_pw
   cert_read_role_arn          = module.certreadrole_ipa_replica1.role.arn
@@ -67,8 +92,8 @@ module "ipa_replica2" {
   }
 
   admin_pw                    = var.admin_pw
-  ami_owner_account_id        = "207871073513" # The COOL Images account
-  associate_public_ip_address = true
+  ami_owner_account_id        = local.images_account_id
+  associate_public_ip_address = false
   cert_bucket_name            = var.cert_bucket_name
   cert_pw                     = var.replica2_cert_pw
   cert_read_role_arn          = module.certreadrole_ipa_replica2.role.arn

--- a/freeipa.tf
+++ b/freeipa.tf
@@ -52,7 +52,6 @@ module "ipa_master" {
   hostname                    = "ipa.${var.cool_domain}"
   private_reverse_zone_id     = data.terraform_remote_state.networking.outputs.private_subnet_private_reverse_zones[local.master_subnet_cidr].id
   private_zone_id             = data.terraform_remote_state.networking.outputs.private_zone.id
-  public_zone_id              = data.aws_route53_zone.public_zone.zone_id
   realm                       = upper(var.cool_domain)
   subnet_id                   = data.terraform_remote_state.networking.outputs.private_subnets[local.master_subnet_cidr].id
   tags                        = var.tags
@@ -77,7 +76,6 @@ module "ipa_replica1" {
   master_hostname             = "ipa.${var.cool_domain}"
   private_reverse_zone_id     = data.terraform_remote_state.networking.outputs.private_subnet_private_reverse_zones[local.replica1_subnet_cidr].id
   private_zone_id             = data.terraform_remote_state.networking.outputs.private_zone.id
-  public_zone_id              = data.aws_route53_zone.public_zone.zone_id
   server_security_group_id    = module.ipa_master.server_security_group.id
   subnet_id                   = data.terraform_remote_state.networking.outputs.private_subnets[local.replica1_subnet_cidr].id
   tags                        = var.tags
@@ -101,7 +99,6 @@ module "ipa_replica2" {
   master_hostname             = "ipa.${var.cool_domain}"
   private_reverse_zone_id     = data.terraform_remote_state.networking.outputs.private_subnet_private_reverse_zones[local.replica2_subnet_cidr].id
   private_zone_id             = data.terraform_remote_state.networking.outputs.private_zone.id
-  public_zone_id              = data.aws_route53_zone.public_zone.zone_id
   server_security_group_id    = module.ipa_master.server_security_group.id
   subnet_id                   = data.terraform_remote_state.networking.outputs.private_subnets[local.replica2_subnet_cidr].id
   tags                        = var.tags

--- a/organization.tf
+++ b/organization.tf
@@ -1,0 +1,5 @@
+# This resource is used to look up account names corresponding to
+# account IDs and vice versa.
+data "aws_organizations_organization" "cool" {
+  provider = aws.organizationsreadonly
+}

--- a/providers.tf
+++ b/providers.tf
@@ -3,9 +3,12 @@ provider "aws" {
   region  = var.aws_region
 }
 
+# This provider isn't used, since we choose not associate public IPs
+# with the FreeIPA master and replicas.  We do, however, have to
+# provide a valid provider to the Terraform module.
 provider "aws" {
   alias   = "public_dns"
-  profile = "cool-olddns-route53fullaccess"
+  profile = "cool-dns-route53resourcechange-cyber.dhs.gov"
   region  = var.aws_region
 }
 

--- a/providers.tf
+++ b/providers.tf
@@ -14,3 +14,9 @@ provider "aws" {
   profile = "cool-dns-provisioncertificatereadroles"
   region  = var.aws_region
 }
+
+provider "aws" {
+  alias   = "organizationsreadonly"
+  profile = "cool-master-organizationsreadonly"
+  region  = var.aws_region
+}

--- a/route53_zones.tf
+++ b/route53_zones.tf
@@ -1,8 +1,0 @@
-#-------------------------------------------------------------------------------
-# Create a data resource for the existing public Route53 zone.
-#-------------------------------------------------------------------------------
-data "aws_route53_zone" "public_zone" {
-  provider = aws.public_dns
-
-  name = var.public_zone_name
-}


### PR DESCRIPTION
## 🗣 Description

In this pull request I modify the code to determine the account "type" (Production or Staging) of the Shared Services account being used, then search for AMIs in the Images account of the same "type".  I also get rid of public IPs and DNS records for the FreeIPA master and replicas, since they now live in private subnets and are not externally accessible.

Even though it isn't being used, I also change the public DNS provider to point to the new DNS account in the COOL.  (We no longer use this provider, but I have to provide a valid provider to the FreeIPA Terraform modules.)

## 💭 Motivation and Context

This change is necessary to be able to seamlessly deploy to both production and staging.

## 🧪 Testing

This code is currently deployed to staging.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
