### PR TITLE
Put PTR records in correct reverse zones

### DIFF
--- a/dns/README.md
+++ b/dns/README.md
@@ -38,8 +38,7 @@ module "example" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | domain | The domain for the IPA master (e.g. example.com). | `string` | n/a | yes |
-| hostname_ip_map | A map whose keys are the hostnames of the IPA servers and whose values are the IPs corresponding to  those servers (e.g. {"ipa0.example.com" = "10.0.0.1", "ipa1.example.com" = "10.0.0.2"}). | `map(string)` | n/a | yes |
-| reverse_zone_id | The zone ID corresponding to the private Route53 reverse zone where the PTR records related to the IPA master should be created (e.g. ZKX36JXQ8W82L). | `string` | n/a | yes |
+| hosts | A map whose keys are the hostnames of the IPA servers and whose values are maps containing the IP and reverse zone ID corresponding to that hostname (e.g. {"ipa0.example.com" = {"ip" = "10.0.0.1", "reverse_zone_id" = "ZKX36JXQ8W82L"}, "ipa1.example.com" = {"ip" = "10.0.0.2", "reverse_zone_id" = "ZKX36JXQ8W93M"}). | `map(object({ip=string, reverse_zone_id=string}))` | n/a | yes |
 | ttl | The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing. | `number` | `86400` | no |
 | zone_id | The zone ID corresponding to the private Route53 zone where the Kerberos-related DNS records should be created (e.g. ZKX36JXQ8W93M). | `string` | n/a | yes |
 

--- a/dns/variables.tf
+++ b/dns/variables.tf
@@ -9,14 +9,9 @@ variable "domain" {
   description = "The domain for the IPA master (e.g. example.com)."
 }
 
-variable "hostname_ip_map" {
-  type        = map(string)
-  description = "A map whose keys are the hostnames of the IPA servers and whose values are the IPs corresponding to  those servers (e.g. {\"ipa0.example.com\" = \"10.0.0.1\", \"ipa1.example.com\" = \"10.0.0.2\"})."
-}
-
-variable "reverse_zone_id" {
-  type        = string
-  description = "The zone ID corresponding to the private Route53 reverse zone where the PTR records related to the IPA master should be created (e.g. ZKX36JXQ8W82L)."
+variable "hosts" {
+  type        = map(object({ ip = string, reverse_zone_id = string }))
+  description = "A map whose keys are the hostnames of the IPA servers and whose values are maps containing the IP and reverse zone ID corresponding to that hostname (e.g. {\"ipa0.example.com\" = {\"ip\" = \"10.0.0.1\", \"reverse_zone_id\" = \"ZKX36JXQ8W82L\"}, \"ipa1.example.com\" = {\"ip\" = \"10.0.0.2\", \"reverse_zone_id\" = \"ZKX36JXQ8W93M\"})."
 }
 
 variable "zone_id" {

--- a/freeipa.tf
+++ b/freeipa.tf
@@ -80,12 +80,20 @@ module "dns" {
   source = "./dns"
 
   domain = var.cool_domain
-  hostname_ip_map = {
-    "ipa0.${var.cool_domain}" = module.ipa0.server.private_ip
-    "ipa1.${var.cool_domain}" = module.ipa1.server.private_ip
-    "ipa2.${var.cool_domain}" = module.ipa2.server.private_ip
+  hosts = {
+    "ipa0.${var.cool_domain}" = {
+      ip              = module.ipa0.server.private_ip
+      reverse_zone_id = data.terraform_remote_state.networking.outputs.private_subnet_private_reverse_zones[local.subnet_cidrs[0]].id
+    }
+    "ipa1.${var.cool_domain}" = {
+      ip              = module.ipa1.server.private_ip
+      reverse_zone_id = data.terraform_remote_state.networking.outputs.private_subnet_private_reverse_zones[local.subnet_cidrs[1]].id
+    }
+    "ipa2.${var.cool_domain}" = {
+      ip              = module.ipa2.server.private_ip
+      reverse_zone_id = data.terraform_remote_state.networking.outputs.private_subnet_private_reverse_zones[local.subnet_cidrs[2]].id
+    }
   }
-  reverse_zone_id = data.terraform_remote_state.networking.outputs.private_subnet_private_reverse_zones[local.subnet_cidrs[0]].id
-  ttl             = var.ttl
-  zone_id         = data.terraform_remote_state.networking.outputs.private_zone.id
+  ttl     = var.ttl
+  zone_id = data.terraform_remote_state.networking.outputs.private_zone.id
 }


### PR DESCRIPTION
## 🗣 Description

This pull request changes the Terraform code to place the PTR records for the IPA servers in the correct reverse zones.  It was previously placing them all in the reverse zone corresponding to the first subnet, which was incorrect.

## 💭 Motivation and Context

The previous implementation resulted in only a single IPA server that could be successfully be reverse-resolved.  I also noted that, when I applied these changes to staging, the only resources that were changed were the PTR records corresponding to the IPA servers in the second and third subnets.

## 🧪 Testing

I have deployed these changes to staging and have found that they alleviate some of the issues that @dav3r and I saw yesterday when deploying.  The rest are alleviated by cisagov/ansible-role-freeipa-client#6 and rebuilt OpenVPN and Guacamole images.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
