### PR TITLE
Improvement/add bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ module "example" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| advertise_ipa_servers | A map whose keys are the leading part of the IPA servers' hostnames and whose keys are boolean values denoting whether that particular server should be advertised as an IPA server (e.g. {"ipa0" = true, "ipa1" = false}).  If the boolean value is false then the A and PTR records for the server are still created, but it is not listed in SVC records, etc. | `map(bool)` | {"ipa0" = true, "ipa1" = true, "ipa2" = true} | no |
 | aws_region | The AWS region where the shared services account is to be created (e.g. "us-east-1"). | `string` | `us-east-1` | no |
 | cool_domain | The domain where the COOL resources reside (e.g. "cool.cyber.dhs.gov"). | `string` | `cool.cyber.dhs.gov` | no |
 | provisionaccount_role_name | The name of the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | `string` | `ProvisionAccount` | no |

--- a/dns/README.md
+++ b/dns/README.md
@@ -4,8 +4,8 @@ This is a Terraform module for creating the DNS records for a FreeIPA
 cluster in the COOL shared services environment.
 
 Note that the DNS records are created such that requests are load
-balanced across all FreeIPA servers listed in the `hostname_ip_map`
-input variable.
+balanced across all FreeIPA servers listed in the `hosts` input
+variable.
 
 ## Usage ##
 
@@ -14,8 +14,18 @@ module "example" {
   source = "./master_dns"
 
   domain          = "example.com"
-  hostname_ip_map = {"ipa.example.com" = "10.0.0.1"}
-  reverse_zone_id = "ZKX36JXQ8W82L"
+  hosts           = {
+    "ipa0.example.com" = {
+      ip              = "10.0.0.1"
+      reverse_zone_id = "ZKX36JXQ8W82L"
+      advertise       = true
+    }
+    "ipa1.example.com" = {
+      ip              = "10.0.0.2"
+      reverse_zone_id = "ZKX36JXQ8W93M"
+      advertise       = false
+    }
+  }
   ttl             = 60
   zone_id         = "ZKX36JXQ8W93M"
 }
@@ -38,7 +48,7 @@ module "example" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | domain | The domain for the IPA master (e.g. example.com). | `string` | n/a | yes |
-| hosts | A map whose keys are the hostnames of the IPA servers and whose values are maps containing the IP and reverse zone ID corresponding to that hostname (e.g. {"ipa0.example.com" = {"ip" = "10.0.0.1", "reverse_zone_id" = "ZKX36JXQ8W82L"}, "ipa1.example.com" = {"ip" = "10.0.0.2", "reverse_zone_id" = "ZKX36JXQ8W93M"}). | `map(object({ip=string, reverse_zone_id=string}))` | n/a | yes |
+| hosts | A map whose keys are the hostnames of the IPA servers and whose values are maps containing the IP and reverse zone ID corresponding to that hostname, as well as a boolean value indicating whether the host should be advertised as an IPA server (e.g. {"ipa0.example.com" = {"ip" = "10.0.0.1", "reverse_zone_id" = "ZKX36JXQ8W82L", "advertise" = true}, "ipa1.example.com" = {"ip" = "10.0.0.2", "reverse_zone_id" = "ZKX36JXQ8W93M", "advertise" = false}).  If the boolean value is false then the A and PTR records for the server are still created, but it is not listed in SVC records, etc. | `map(object({ ip = string, reverse_zone_id = string, advertise = bool }))` | n/a | yes |
 | ttl | The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing. | `number` | `86400` | no |
 | zone_id | The zone ID corresponding to the private Route53 zone where the Kerberos-related DNS records should be created (e.g. ZKX36JXQ8W93M). | `string` | n/a | yes |
 

--- a/dns/dns.tf
+++ b/dns/dns.tf
@@ -39,6 +39,7 @@ resource "aws_route53_record" "ca_A" {
   records = [
     for hostname, m in var.hosts :
     m["ip"]
+    if m["advertise"]
   ]
 }
 
@@ -62,6 +63,7 @@ resource "aws_route53_record" "master_SRV" {
   records = [
     for hostname, m in var.hosts :
     "0 100 88 ${hostname}"
+    if m["advertise"]
   ]
 }
 
@@ -75,6 +77,7 @@ resource "aws_route53_record" "server_SRV" {
   records = [
     for hostname, m in var.hosts :
     "0 100 88 ${hostname}"
+    if m["advertise"]
   ]
 }
 
@@ -88,6 +91,7 @@ resource "aws_route53_record" "password_SRV" {
   records = [
     for hostname, m in var.hosts :
     "0 100 464 ${hostname}"
+    if m["advertise"]
   ]
 }
 
@@ -99,6 +103,7 @@ resource "aws_route53_record" "ldap_SRV" {
   records = [
     for hostname, m in var.hosts :
     "0 100 389 ${hostname}"
+    if m["advertise"]
   ]
 }
 
@@ -110,5 +115,6 @@ resource "aws_route53_record" "ldaps_SRV" {
   records = [
     for hostname, m in var.hosts :
     "0 100 636 ${hostname}"
+    if m["advertise"]
   ]
 }

--- a/dns/variables.tf
+++ b/dns/variables.tf
@@ -10,8 +10,8 @@ variable "domain" {
 }
 
 variable "hosts" {
-  type        = map(object({ ip = string, reverse_zone_id = string }))
-  description = "A map whose keys are the hostnames of the IPA servers and whose values are maps containing the IP and reverse zone ID corresponding to that hostname (e.g. {\"ipa0.example.com\" = {\"ip\" = \"10.0.0.1\", \"reverse_zone_id\" = \"ZKX36JXQ8W82L\"}, \"ipa1.example.com\" = {\"ip\" = \"10.0.0.2\", \"reverse_zone_id\" = \"ZKX36JXQ8W93M\"})."
+  type        = map(object({ ip = string, reverse_zone_id = string, advertise = bool }))
+  description = "A map whose keys are the hostnames of the IPA servers and whose values are maps containing the IP and reverse zone ID corresponding to that hostname, as well as a boolean value indicating whether the host should be advertised as an IPA server (e.g. {\"ipa0.example.com\" = {\"ip\" = \"10.0.0.1\", \"reverse_zone_id\" = \"ZKX36JXQ8W82L\", \"advertise\" = true}, \"ipa1.example.com\" = {\"ip\" = \"10.0.0.2\", \"reverse_zone_id\" = \"ZKX36JXQ8W93M\", \"advertise\" = false}).  If the boolean value is false then the A and PTR records for the server are still created, but it is not listed in SVC records, etc."
 }
 
 variable "zone_id" {

--- a/freeipa.tf
+++ b/freeipa.tf
@@ -33,11 +33,11 @@ locals {
   # The IP addresses of the IPA servers.  AWS reserves the first four
   # and the last IP address in each subnet.
   #
-  # The latest version of cisagov/freeipa-server-tf-module requires us
-  # to assign IPs in order to break the dependency of DNS record
-  # resources on the corresponding EC2 instance resources; otherwise,
-  # it is not possible to recreate the IPA servers one by one as is
-  # required when a new FreeIPA AMI is made available.
+  # cisagov/freeipa-server-tf-module now requires us to assign IPs in
+  # order to break the dependency of DNS record resources on the
+  # corresponding EC2 instance resources; otherwise, it is not
+  # possible to recreate the IPA servers one by one as is required
+  # when a new FreeIPA AMI is made available.
   ipa_ips = [for cidr in local.subnet_cidrs : cidrhost(cidr, 4)]
 }
 

--- a/freeipa.tf
+++ b/freeipa.tf
@@ -95,17 +95,17 @@ module "dns" {
     "ipa0.${var.cool_domain}" = {
       ip              = local.ipa_ips[0]
       reverse_zone_id = data.terraform_remote_state.networking.outputs.private_subnet_private_reverse_zones[local.subnet_cidrs[0]].id
-      advertise       = true
+      advertise       = var.advertise_ipa_servers["ipa0"]
     }
     "ipa1.${var.cool_domain}" = {
       ip              = local.ipa_ips[1]
       reverse_zone_id = data.terraform_remote_state.networking.outputs.private_subnet_private_reverse_zones[local.subnet_cidrs[1]].id
-      advertise       = true
+      advertise       = var.advertise_ipa_servers["ipa1"]
     }
     "ipa2.${var.cool_domain}" = {
       ip              = local.ipa_ips[2]
       reverse_zone_id = data.terraform_remote_state.networking.outputs.private_subnet_private_reverse_zones[local.subnet_cidrs[2]].id
-      advertise       = true
+      advertise       = var.advertise_ipa_servers["ipa2"]
     }
   }
   ttl     = var.ttl

--- a/freeipa.tf
+++ b/freeipa.tf
@@ -29,6 +29,16 @@ locals {
 
   # The subnets where the IPA servers are to be placed
   subnet_cidrs = keys(data.terraform_remote_state.networking.outputs.private_subnets)
+
+  # The IP addresses of the IPA servers.  AWS reserves the first four
+  # and the last IP address in each subnet.
+  #
+  # The latest version of cisagov/freeipa-server-tf-module requires us
+  # to assign IPs in order to break the dependency of DNS record
+  # resources on the corresponding EC2 instance resources; otherwise,
+  # it is not possible to recreate the IPA servers one by one as is
+  # required when a new FreeIPA AMI is made available.
+  ipa_ips = [for cidr in local.subnet_cidrs : cidrhost(cidr, 4)]
 }
 
 # Create the IPA client and server security groups
@@ -47,6 +57,7 @@ module "ipa0" {
   ami_owner_account_id = local.images_account_id
   domain               = var.cool_domain
   hostname             = "ipa0.${var.cool_domain}"
+  ip                   = local.ipa_ips[0]
   realm                = upper(var.cool_domain)
   security_group_ids   = [module.security_groups.server.id]
   subnet_id            = data.terraform_remote_state.networking.outputs.private_subnets[local.subnet_cidrs[0]].id
@@ -58,7 +69,7 @@ module "ipa1" {
   ami_owner_account_id = local.images_account_id
   domain               = var.cool_domain
   hostname             = "ipa1.${var.cool_domain}"
-  realm                = upper(var.cool_domain)
+  ip                   = local.ipa_ips[1]
   security_group_ids   = [module.security_groups.server.id]
   subnet_id            = data.terraform_remote_state.networking.outputs.private_subnets[local.subnet_cidrs[1]].id
   tags                 = merge(var.tags, map("Name", "FreeIPA 1"))
@@ -69,7 +80,7 @@ module "ipa2" {
   ami_owner_account_id = local.images_account_id
   domain               = var.cool_domain
   hostname             = "ipa2.${var.cool_domain}"
-  realm                = upper(var.cool_domain)
+  ip                   = local.ipa_ips[2]
   security_group_ids   = [module.security_groups.server.id]
   subnet_id            = data.terraform_remote_state.networking.outputs.private_subnets[local.subnet_cidrs[2]].id
   tags                 = merge(var.tags, map("Name", "FreeIPA 2"))
@@ -82,16 +93,19 @@ module "dns" {
   domain = var.cool_domain
   hosts = {
     "ipa0.${var.cool_domain}" = {
-      ip              = module.ipa0.server.private_ip
+      ip              = local.ipa_ips[0]
       reverse_zone_id = data.terraform_remote_state.networking.outputs.private_subnet_private_reverse_zones[local.subnet_cidrs[0]].id
+      advertise       = true
     }
     "ipa1.${var.cool_domain}" = {
-      ip              = module.ipa1.server.private_ip
+      ip              = local.ipa_ips[1]
       reverse_zone_id = data.terraform_remote_state.networking.outputs.private_subnet_private_reverse_zones[local.subnet_cidrs[1]].id
+      advertise       = true
     }
     "ipa2.${var.cool_domain}" = {
-      ip              = module.ipa2.server.private_ip
+      ip              = local.ipa_ips[2]
       reverse_zone_id = data.terraform_remote_state.networking.outputs.private_subnet_private_reverse_zones[local.subnet_cidrs[2]].id
+      advertise       = true
     }
   }
   ttl     = var.ttl

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,16 @@
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
 
+variable "advertise_ipa_servers" {
+  type        = map(bool)
+  description = "A map whose keys are the leading part of the IPA servers' hostnames and whose keys are boolean values denoting whether that particular server should be advertised as an IPA server (e.g. {\"ipa0\" = true, \"ipa1\" = false}).  If the boolean value is false then the A and PTR records for the server are still created, but it is not listed in SVC records, etc."
+  default = {
+    "ipa0" = true
+    "ipa1" = true
+    "ipa2" = true
+  }
+}
+
 variable "aws_region" {
   type        = string
   description = "The AWS region where the shared services account is to be created (e.g. \"us-east-1\")."


### PR DESCRIPTION
## 🗣 Description

This pull request:
1. Allows IPA servers not to be advertised as such.
1. Explicitly sets the IPs of IPA servers.
1. Removes the `realm` variable from the module configuration for IPA replicas.

## 💭 Motivation and Context

1. We want to be able to remove IPA servers from the list advertised as such when we take them offline and recreate them because a new FreeIPA server AMI has been made available.
1. In cisagov/freeipa-server-tf-module#26 we started requiring the user to explicitly set the IP address to use for IPA servers in order to break the dependency of DNS record resources on the corresponding EC2 instance resources; otherwise, it is not possible to recreate the EC2 instances one by one when a new FreeIPA server AMI is made available.
1. The `realm` variable is not used at all when setting up an IPA replica, so there is no reason it should be specified.

See also cisagov/ansible-role-freeipa-server#10 and cisagov/freeipa-server-tf-module#26.

## 🧪 Testing

I have used this code to successfully redeploy the FreeIPA server cluster in our staging environment.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
