### PR TITLE
Upgrade to use version 3.X of the AWS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,22 +41,22 @@ module "example" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
-| aws.organizationsreadonly | ~> 2.0 |
-| aws.sharedservicesprovisionaccount | ~> 2.0 |
+| aws | ~> 3.0 |
+| aws.organizationsreadonly | ~> 3.0 |
+| aws.sharedservicesprovisionaccount | ~> 3.0 |
 | terraform | n/a |
 
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| advertise_ipa_servers | A map whose keys are the leading part of the IPA servers' hostnames and whose keys are boolean values denoting whether that particular server should be advertised as an IPA server (e.g. {"ipa0" = true, "ipa1" = false}).  If the boolean value is false then the A and PTR records for the server are still created, but it is not listed in SVC records, etc. | `map(bool)` | {"ipa0" = true, "ipa1" = true, "ipa2" = true} | no |
+| advertise_ipa_servers | A map whose keys are the leading part of the IPA servers' hostnames and whose keys are boolean values denoting whether that particular server should be advertised as an IPA server (e.g. {"ipa0" = true, "ipa1" = false}).  If the boolean value is false then the A and PTR records for the server are still created, but it is not listed in SVC records, etc. | `map(bool)` | `{"ipa0": true, "ipa1": true, "ipa2": true}` | no |
 | aws_region | The AWS region where the shared services account is to be created (e.g. "us-east-1"). | `string` | `us-east-1` | no |
 | cool_domain | The domain where the COOL resources reside (e.g. "cool.cyber.dhs.gov"). | `string` | `cool.cyber.dhs.gov` | no |
 | provisionaccount_role_name | The name of the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | `string` | `ProvisionAccount` | no |

--- a/dns/README.md
+++ b/dns/README.md
@@ -36,13 +36,13 @@ module "example" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs ##
 

--- a/dns/versions.tf
+++ b/dns/versions.tf
@@ -6,6 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/security_groups/README.md
+++ b/security_groups/README.md
@@ -23,13 +23,13 @@ module "example" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs ##
 

--- a/security_groups/versions.tf
+++ b/security_groups/versions.tf
@@ -6,6 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,6 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }


### PR DESCRIPTION
## 🗣 Description

This pull request updates this repository to use version 3.x of the AWS Terraform provider.

See also cisagov/freeipa-server-tf-module#36.

## 💭 Motivation and Context

Version 3.X of the AWS provider has been out for a while now and has stabilized.  We should upgrade before we get left behind.

## 🧪 Testing

I successfully ran a `terraform apply` for this repository in our staging COOL environment using these changes and those in cisagov/freeipa-server-tf-module#36.  No resources needed to be changed.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [x] Update Terraform provider

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
