### PR TITLE
Reduce the default TTL value

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ module "example" {
 | provisionfreeipa_policy_name | The name to assign the IAM policy that allows provisioning of FreeIPA in the Shared Services account. | `string` | `ProvisionFreeIPA` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 | trusted_cidr_blocks | A list of the CIDR blocks outside the VPC that are allowed to access the IPA servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]). | `list(string)` | `[]` | no |
-| ttl | The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing. | `number` | `86400` | no |
+| ttl | The TTL value to use for Route53 DNS records (e.g. 3600).  A smaller value may be useful when the DNS records are changing often, for example when testing. | `number` | `3600` | no |
 
 ## Outputs ##
 

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,6 @@ variable "trusted_cidr_blocks" {
 
 variable "ttl" {
   type        = number
-  description = "The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing."
-  default     = 86400
+  description = "The TTL value to use for Route53 DNS records (e.g. 3600).  A smaller value may be useful when the DNS records are changing often, for example when testing."
+  default     = 3600
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request reduces the default TTL value for the FreeIPA-related DNS records.

## 💭 Motivation and context ##

Note that we reduce the default TTL from `86400` (24 hours) to `3600` (one hour).  This way we can change the value to, say, `60` an hour before redeploying the FreeIPA cluster and avoid situations such as that described in cisagov/cool-system#150.

Resolves cisagov/cool-system#150.

## 🧪 Testing ##

All `pre-commit` hooks pass.  These changes are already deployed to our production and staging COOL environments.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
