### PR TITLE
Add the VENOM security group to the FreeIPA instances

### DIFF
--- a/freeipa.tf
+++ b/freeipa.tf
@@ -41,9 +41,12 @@ module "ipa0" {
   hostname             = "ipa0.${var.cool_domain}"
   ip                   = local.ipa_ips[0]
   realm                = upper(var.cool_domain)
-  security_group_ids   = [module.security_groups.server.id]
-  subnet_id            = data.terraform_remote_state.networking.outputs.private_subnets[local.subnet_cidrs[0]].id
-  tags                 = merge(var.tags, map("Name", "FreeIPA 0"))
+  security_group_ids = [
+    module.security_groups.server.id,
+    data.terraform_remote_state.venom.outputs.venom_security_group.id,
+  ]
+  subnet_id = data.terraform_remote_state.networking.outputs.private_subnets[local.subnet_cidrs[0]].id
+  tags      = merge(var.tags, map("Name", "FreeIPA 0"))
 }
 module "ipa1" {
   source = "github.com/cisagov/freeipa-server-tf-module"
@@ -55,9 +58,12 @@ module "ipa1" {
   domain               = var.cool_domain
   hostname             = "ipa1.${var.cool_domain}"
   ip                   = local.ipa_ips[1]
-  security_group_ids   = [module.security_groups.server.id]
-  subnet_id            = data.terraform_remote_state.networking.outputs.private_subnets[local.subnet_cidrs[1]].id
-  tags                 = merge(var.tags, map("Name", "FreeIPA 1"))
+  security_group_ids = [
+    module.security_groups.server.id,
+    data.terraform_remote_state.venom.outputs.venom_security_group.id,
+  ]
+  subnet_id = data.terraform_remote_state.networking.outputs.private_subnets[local.subnet_cidrs[1]].id
+  tags      = merge(var.tags, map("Name", "FreeIPA 1"))
 }
 module "ipa2" {
   source = "github.com/cisagov/freeipa-server-tf-module"
@@ -69,9 +75,12 @@ module "ipa2" {
   domain               = var.cool_domain
   hostname             = "ipa2.${var.cool_domain}"
   ip                   = local.ipa_ips[2]
-  security_group_ids   = [module.security_groups.server.id]
-  subnet_id            = data.terraform_remote_state.networking.outputs.private_subnets[local.subnet_cidrs[2]].id
-  tags                 = merge(var.tags, map("Name", "FreeIPA 2"))
+  security_group_ids = [
+    module.security_groups.server.id,
+    data.terraform_remote_state.venom.outputs.venom_security_group.id,
+  ]
+  subnet_id = data.terraform_remote_state.networking.outputs.private_subnets[local.subnet_cidrs[2]].id
+  tags      = merge(var.tags, map("Name", "FreeIPA 2"))
 }
 
 # Create the DNS entries for the IPA cluster

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -63,3 +63,18 @@ data "terraform_remote_state" "sharedservices" {
 
   workspace = terraform.workspace
 }
+
+data "terraform_remote_state" "venom" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "cool-sharedservices-venom/terraform.tfstate"
+  }
+
+  workspace = terraform.workspace
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the VENOM security group to the FreeIPA instances.

## 💭 Motivation and context ##

This change will allow the VENOM agents running on the FreeIPA instances to communicate with resources in the VENOM environment.  This is required for integration with the VENOM environment.

## 🧪 Testing ##

All `pre-commit` hooks pass.  These changes have already been applied to the COOL staging environment.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
