### PR TITLE
Correctly reference CDM security group

### DIFF
--- a/freeipa.tf
+++ b/freeipa.tf
@@ -43,7 +43,7 @@ module "ipa0" {
   realm                = upper(var.cool_domain)
   security_group_ids = [
     module.security_groups.server.id,
-    data.terraform_remote_state.venom.outputs.venom_security_group.id,
+    data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
   ]
   subnet_id = data.terraform_remote_state.networking.outputs.private_subnets[local.subnet_cidrs[0]].id
   tags      = merge(var.tags, map("Name", "FreeIPA 0"))
@@ -60,7 +60,7 @@ module "ipa1" {
   ip                   = local.ipa_ips[1]
   security_group_ids = [
     module.security_groups.server.id,
-    data.terraform_remote_state.venom.outputs.venom_security_group.id,
+    data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
   ]
   subnet_id = data.terraform_remote_state.networking.outputs.private_subnets[local.subnet_cidrs[1]].id
   tags      = merge(var.tags, map("Name", "FreeIPA 1"))
@@ -77,7 +77,7 @@ module "ipa2" {
   ip                   = local.ipa_ips[2]
   security_group_ids = [
     module.security_groups.server.id,
-    data.terraform_remote_state.venom.outputs.venom_security_group.id,
+    data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
   ]
   subnet_id = data.terraform_remote_state.networking.outputs.private_subnets[local.subnet_cidrs[2]].id
   tags      = merge(var.tags, map("Name", "FreeIPA 2"))

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -64,7 +64,7 @@ data "terraform_remote_state" "sharedservices" {
   workspace = terraform.workspace
 }
 
-data "terraform_remote_state" "venom" {
+data "terraform_remote_state" "cdm" {
   backend = "s3"
 
   config = {
@@ -73,7 +73,7 @@ data "terraform_remote_state" "venom" {
     dynamodb_table = "terraform-state-lock"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-sharedservices-venom/terraform.tfstate"
+    key            = "cool-sharedservices-cdm/terraform.tfstate"
   }
 
   workspace = terraform.workspace


### PR DESCRIPTION
## 🗣 Description ##

This pull request adjusts the Terraform code to correctly reference the CDM security group.

## 💭 Motivation and context ##

The remote state containing the CDM security group, and the Terraform resource name corresponding to it, have both changes names; therefore the references to them must also be updated.

## 🧪 Testing ##

I successfully applied these changes to our COOL staging environment.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
