### PR TITLE
Reduce default TTL from 3600 to 60

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ module "example" {
 | provisionfreeipa\_policy\_name | The name to assign the IAM policy that allows provisioning of FreeIPA in the Shared Services account. | `string` | `"ProvisionFreeIPA"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 | trusted\_cidr\_blocks | A list of the CIDR blocks outside the VPC that are allowed to access the IPA servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]). | `list(string)` | `[]` | no |
-| ttl | The TTL value to use for Route53 DNS records (e.g. 3600).  A smaller value may be useful when the DNS records are changing often, for example when testing. | `number` | `3600` | no |
+| ttl | The TTL value to use for Route53 DNS records (e.g. 60). | `number` | `60` | no |
 
 ## Outputs ##
 

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,6 @@ variable "trusted_cidr_blocks" {
 
 variable "ttl" {
   type        = number
-  description = "The TTL value to use for Route53 DNS records (e.g. 3600).  A smaller value may be useful when the DNS records are changing often, for example when testing."
-  default     = 3600
+  description = "The TTL value to use for Route53 DNS records (e.g. 60)."
+  default     = 60
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request reduces the default TTL for FreeIPA-related DNS records from 3600 to 60.

## 💭 Motivation and context ##

It makes sense to reduce the default TTL to 60, since I intend to eventually add code to automatically update FreeIPA DNS records depending on the status of health checks.  I am making this change now so that there is one less step I have to do when I upgrade the FreeIPA cluster, and also so I don't have to wait an hour (for the previous default TTL of 3600 to time out) before making changes.

AWS itself sets a TTL of 60 for most of their records to allow them to be updated at will without causing anything more than a very temporary glitch.

## 🧪 Testing ##

These changes have been successfully deployed to our staging COOL environment.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Edit [this wiki page](https://github.com/cisagov/cool-system/wiki/Upgrading-the-FreeIPA-cluster) to remove all mention of adjusting the TTL for DNS records.