### PR TITLE
Allow specification of root disk size

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ module "example" {
 | provisionaccount\_role\_name | The name of the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | `string` | `"ProvisionAccount"` | no |
 | provisionfreeipa\_policy\_description | The description to associate with the IAM policy that allows provisioning of FreeIPA in the Shared Services account. | `string` | `"Allows provisioning of FreeIPA in the Shared Services account."` | no |
 | provisionfreeipa\_policy\_name | The name to assign the IAM policy that allows provisioning of FreeIPA in the Shared Services account. | `string` | `"ProvisionFreeIPA"` | no |
-| root\_disk\_size | The size of the IPA instance's root disk in GB. | `number` | `8` | no |
+| root\_disk\_size | The size of the IPA instance's root disk in GiB. | `number` | `8` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 | trusted\_cidr\_blocks | A list of the CIDR blocks outside the VPC that are allowed to access the IPA servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]). | `list(string)` | `[]` | no |
 | ttl | The TTL value to use for Route53 DNS records (e.g. 60). | `number` | `60` | no |

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ module "example" {
 | provisionaccount\_role\_name | The name of the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | `string` | `"ProvisionAccount"` | no |
 | provisionfreeipa\_policy\_description | The description to associate with the IAM policy that allows provisioning of FreeIPA in the Shared Services account. | `string` | `"Allows provisioning of FreeIPA in the Shared Services account."` | no |
 | provisionfreeipa\_policy\_name | The name to assign the IAM policy that allows provisioning of FreeIPA in the Shared Services account. | `string` | `"ProvisionFreeIPA"` | no |
+| root\_disk\_size | The size of the IPA instance's root disk in GB. | `number` | `8` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 | trusted\_cidr\_blocks | A list of the CIDR blocks outside the VPC that are allowed to access the IPA servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]). | `list(string)` | `[]` | no |
 | ttl | The TTL value to use for Route53 DNS records (e.g. 60). | `number` | `60` | no |

--- a/freeipa.tf
+++ b/freeipa.tf
@@ -44,6 +44,7 @@ module "ipa0" {
   nessus_key_key       = var.nessus_key_key
   nessus_port_key      = var.nessus_port_key
   realm                = upper(var.cool_domain)
+  root_disk_size       = var.root_disk_size
   security_group_ids = [
     module.security_groups.server.id,
     data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
@@ -64,6 +65,7 @@ module "ipa1" {
   nessus_hostname_key  = var.nessus_hostname_key
   nessus_key_key       = var.nessus_key_key
   nessus_port_key      = var.nessus_port_key
+  root_disk_size       = var.root_disk_size
   security_group_ids = [
     module.security_groups.server.id,
     data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
@@ -84,6 +86,7 @@ module "ipa2" {
   nessus_hostname_key  = var.nessus_hostname_key
   nessus_key_key       = var.nessus_key_key
   nessus_port_key      = var.nessus_port_key
+  root_disk_size       = var.root_disk_size
   security_group_ids = [
     module.security_groups.server.id,
     data.terraform_remote_state.cdm.outputs.cdm_security_group.id,

--- a/variables.tf
+++ b/variables.tf
@@ -64,7 +64,7 @@ variable "provisionfreeipa_policy_name" {
 
 variable "root_disk_size" {
   type        = number
-  description = "The size of the IPA instance's root disk in GB."
+  description = "The size of the IPA instance's root disk in GiB."
   default     = 8
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,12 @@ variable "provisionfreeipa_policy_name" {
   default     = "ProvisionFreeIPA"
 }
 
+variable "root_disk_size" {
+  type        = number
+  description = "The size of the IPA instance's root disk in GB."
+  default     = 8
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to all AWS resources created."


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds an optional variable to specify the size of the root disk for IPA servers.  The variable's value defaults to 8GB, which is the size of the root disk in the corresponding AMI.

See also cisagov/freeipa-server-tf-module#52.

## 💭 Motivation and context ##

In some cases it makes sense to have more space than the 8GB size of the AMI.

## 🧪 Testing ##

I have successfully applied these changes to our production COOL environment.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.