### PR TITLE
Add some security groups to the FreeIPA instances

### DIFF
--- a/freeipa.tf
+++ b/freeipa.tf
@@ -49,6 +49,10 @@ module "ipa0" {
   security_group_ids = [
     module.security_groups.server.id,
     data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
+    data.terraform_remote_state.networking.outputs.cloudwatch_agent_endpoint_client_security_group.id,
+    data.terraform_remote_state.networking.outputs.ssm_agent_endpoint_client_security_group.id,
+    # Used to pull the CDM agent parameters from SSM
+    data.terraform_remote_state.networking.outputs.ssm_endpoint_client_security_group.id,
   ]
   subnet_id = data.terraform_remote_state.networking.outputs.private_subnets[local.subnet_cidrs[0]].id
 }
@@ -71,6 +75,10 @@ module "ipa1" {
   security_group_ids = [
     module.security_groups.server.id,
     data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
+    data.terraform_remote_state.networking.outputs.cloudwatch_agent_endpoint_client_security_group.id,
+    data.terraform_remote_state.networking.outputs.ssm_agent_endpoint_client_security_group.id,
+    # Used to pull the CDM agent parameters from SSM
+    data.terraform_remote_state.networking.outputs.ssm_endpoint_client_security_group.id,
   ]
   subnet_id = data.terraform_remote_state.networking.outputs.private_subnets[local.subnet_cidrs[1]].id
 }
@@ -93,6 +101,10 @@ module "ipa2" {
   security_group_ids = [
     module.security_groups.server.id,
     data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
+    data.terraform_remote_state.networking.outputs.cloudwatch_agent_endpoint_client_security_group.id,
+    data.terraform_remote_state.networking.outputs.ssm_agent_endpoint_client_security_group.id,
+    # Used to pull the CDM agent parameters from SSM
+    data.terraform_remote_state.networking.outputs.ssm_endpoint_client_security_group.id,
   ]
   subnet_id = data.terraform_remote_state.networking.outputs.private_subnets[local.subnet_cidrs[2]].id
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds some security groups to the FreeIPA instances.

## 💭 Motivation and context ##

The FreeIPA instances require these security groups to communicate with the VPC endpoints created in cisagov/cool-sharedservices-networking#71.

## 🧪 Testing ##

All automated tests pass.  I also applied these changes to our COOL staging environment and verified that they function as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.