### PR TITLE
Update use of FreeIPA module to configure Crowdstrike Falcon sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ module "example" {
 |------|-------------|------|---------|:--------:|
 | aws\_region | The AWS region where the shared services account is to be created (e.g. "us-east-1"). | `string` | `"us-east-1"` | no |
 | cool\_domain | The domain where the COOL resources reside (e.g. "cool.cyber.dhs.gov"). | `string` | `"cool.cyber.dhs.gov"` | no |
+| crowdstrike\_falcon\_sensor\_customer\_id\_key | The SSM Parameter Store key whose corresponding value contains the customer ID for CrowdStrike Falcon (e.g. /cdm/falcon/customer\_id). | `string` | `"/cdm/falcon/customer_id"` | no |
+| crowdstrike\_falcon\_sensor\_tags\_key | The SSM Parameter Store key whose corresponding value contains a comma-delimited list of tags that are to be applied to CrowdStrike Falcon (e.g. /cdm/falcon/tags). | `string` | `"/cdm/falcon/tags"` | no |
 | nessus\_hostname\_key | The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus/hostname). | `string` | `"/cdm/nessus_hostname"` | no |
 | nessus\_key\_key | The SSM Parameter Store key whose corresponding value contains the secret key that the Nessus Agent should use when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/key). | `string` | `"/cdm/nessus_key"` | no |
 | nessus\_port\_key | The SSM Parameter Store key whose corresponding value contains the port to which the Nessus Agent should connect when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/port). | `string` | `"/cdm/nessus_port"` | no |

--- a/freeipa.tf
+++ b/freeipa.tf
@@ -34,7 +34,7 @@ module "ipa0" {
     aws                                   = aws.sharedservicesprovisionaccount_ipa0
     aws.provision_ssm_parameter_read_role = aws.provision_ssm_parameter_read_role
   }
-  source = "github.com/cisagov/freeipa-server-tf-module?ref=improvement%2Fadd-crowdstrike-falcon"
+  source = "github.com/cisagov/freeipa-server-tf-module"
 
   ami_owner_account_id                      = local.images_account_id
   crowdstrike_falcon_sensor_customer_id_key = var.crowdstrike_falcon_sensor_customer_id_key
@@ -63,7 +63,7 @@ module "ipa1" {
     aws                                   = aws.sharedservicesprovisionaccount_ipa1
     aws.provision_ssm_parameter_read_role = aws.provision_ssm_parameter_read_role
   }
-  source = "github.com/cisagov/freeipa-server-tf-module?ref=improvement%2Fadd-crowdstrike-falcon"
+  source = "github.com/cisagov/freeipa-server-tf-module"
 
   ami_owner_account_id                      = local.images_account_id
   crowdstrike_falcon_sensor_customer_id_key = var.crowdstrike_falcon_sensor_customer_id_key
@@ -91,7 +91,7 @@ module "ipa2" {
     aws                                   = aws.sharedservicesprovisionaccount_ipa2
     aws.provision_ssm_parameter_read_role = aws.provision_ssm_parameter_read_role
   }
-  source = "github.com/cisagov/freeipa-server-tf-module?ref=improvement%2Fadd-crowdstrike-falcon"
+  source = "github.com/cisagov/freeipa-server-tf-module"
 
   ami_owner_account_id                      = local.images_account_id
   crowdstrike_falcon_sensor_customer_id_key = var.crowdstrike_falcon_sensor_customer_id_key

--- a/freeipa.tf
+++ b/freeipa.tf
@@ -34,18 +34,20 @@ module "ipa0" {
     aws                                   = aws.sharedservicesprovisionaccount_ipa0
     aws.provision_ssm_parameter_read_role = aws.provision_ssm_parameter_read_role
   }
-  source = "github.com/cisagov/freeipa-server-tf-module"
+  source = "github.com/cisagov/freeipa-server-tf-module?ref=improvement%2Fadd-crowdstrike-falcon"
 
-  ami_owner_account_id = local.images_account_id
-  domain               = var.cool_domain
-  hostname             = "ipa0.${var.cool_domain}"
-  ip                   = local.ipa_ips[0]
-  nessus_hostname_key  = var.nessus_hostname_key
-  nessus_key_key       = var.nessus_key_key
-  nessus_port_key      = var.nessus_port_key
-  netbios_name         = var.netbios_name
-  realm                = upper(var.cool_domain)
-  root_disk_size       = var.root_disk_size
+  ami_owner_account_id                      = local.images_account_id
+  crowdstrike_falcon_sensor_customer_id_key = var.crowdstrike_falcon_sensor_customer_id_key
+  crowdstrike_falcon_sensor_tags_key        = var.crowdstrike_falcon_sensor_tags_key
+  domain                                    = var.cool_domain
+  hostname                                  = "ipa0.${var.cool_domain}"
+  ip                                        = local.ipa_ips[0]
+  nessus_hostname_key                       = var.nessus_hostname_key
+  nessus_key_key                            = var.nessus_key_key
+  nessus_port_key                           = var.nessus_port_key
+  netbios_name                              = var.netbios_name
+  realm                                     = upper(var.cool_domain)
+  root_disk_size                            = var.root_disk_size
   security_group_ids = [
     module.security_groups.server.id,
     data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
@@ -61,17 +63,19 @@ module "ipa1" {
     aws                                   = aws.sharedservicesprovisionaccount_ipa1
     aws.provision_ssm_parameter_read_role = aws.provision_ssm_parameter_read_role
   }
-  source = "github.com/cisagov/freeipa-server-tf-module"
+  source = "github.com/cisagov/freeipa-server-tf-module?ref=improvement%2Fadd-crowdstrike-falcon"
 
-  ami_owner_account_id = local.images_account_id
-  domain               = var.cool_domain
-  hostname             = "ipa1.${var.cool_domain}"
-  ip                   = local.ipa_ips[1]
-  nessus_hostname_key  = var.nessus_hostname_key
-  nessus_key_key       = var.nessus_key_key
-  nessus_port_key      = var.nessus_port_key
-  netbios_name         = var.netbios_name
-  root_disk_size       = var.root_disk_size
+  ami_owner_account_id                      = local.images_account_id
+  crowdstrike_falcon_sensor_customer_id_key = var.crowdstrike_falcon_sensor_customer_id_key
+  crowdstrike_falcon_sensor_tags_key        = var.crowdstrike_falcon_sensor_tags_key
+  domain                                    = var.cool_domain
+  hostname                                  = "ipa1.${var.cool_domain}"
+  ip                                        = local.ipa_ips[1]
+  nessus_hostname_key                       = var.nessus_hostname_key
+  nessus_key_key                            = var.nessus_key_key
+  nessus_port_key                           = var.nessus_port_key
+  netbios_name                              = var.netbios_name
+  root_disk_size                            = var.root_disk_size
   security_group_ids = [
     module.security_groups.server.id,
     data.terraform_remote_state.cdm.outputs.cdm_security_group.id,
@@ -87,17 +91,19 @@ module "ipa2" {
     aws                                   = aws.sharedservicesprovisionaccount_ipa2
     aws.provision_ssm_parameter_read_role = aws.provision_ssm_parameter_read_role
   }
-  source = "github.com/cisagov/freeipa-server-tf-module"
+  source = "github.com/cisagov/freeipa-server-tf-module?ref=improvement%2Fadd-crowdstrike-falcon"
 
-  ami_owner_account_id = local.images_account_id
-  domain               = var.cool_domain
-  hostname             = "ipa2.${var.cool_domain}"
-  ip                   = local.ipa_ips[2]
-  nessus_hostname_key  = var.nessus_hostname_key
-  nessus_key_key       = var.nessus_key_key
-  nessus_port_key      = var.nessus_port_key
-  netbios_name         = var.netbios_name
-  root_disk_size       = var.root_disk_size
+  ami_owner_account_id                      = local.images_account_id
+  crowdstrike_falcon_sensor_customer_id_key = var.crowdstrike_falcon_sensor_customer_id_key
+  crowdstrike_falcon_sensor_tags_key        = var.crowdstrike_falcon_sensor_tags_key
+  domain                                    = var.cool_domain
+  hostname                                  = "ipa2.${var.cool_domain}"
+  ip                                        = local.ipa_ips[2]
+  nessus_hostname_key                       = var.nessus_hostname_key
+  nessus_key_key                            = var.nessus_key_key
+  nessus_port_key                           = var.nessus_port_key
+  netbios_name                              = var.netbios_name
+  root_disk_size                            = var.root_disk_size
   security_group_ids = [
     module.security_groups.server.id,
     data.terraform_remote_state.cdm.outputs.cdm_security_group.id,

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,18 @@ variable "cool_domain" {
   default     = "cool.cyber.dhs.gov"
 }
 
+variable "crowdstrike_falcon_sensor_customer_id_key" {
+  type        = string
+  description = "The SSM Parameter Store key whose corresponding value contains the customer ID for CrowdStrike Falcon (e.g. /cdm/falcon/customer_id)."
+  default     = "/cdm/falcon/customer_id"
+}
+
+variable "crowdstrike_falcon_sensor_tags_key" {
+  type        = string
+  description = "The SSM Parameter Store key whose corresponding value contains a comma-delimited list of tags that are to be applied to CrowdStrike Falcon (e.g. /cdm/falcon/tags)."
+  default     = "/cdm/falcon/tags"
+}
+
 variable "nessus_hostname_key" {
   type        = string
   description = "The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus/hostname)."


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the use of [cisagov/freeipa-server-tf-module](https://github.com/cisagov/freeipa-server-tf-module) to allow for the configuration of the Crowdstrike Falcon sensor.

## 💭 Motivation and context ##

The Crowdstrike Falcon sensor will not function as expected unless properly configured.

## 🧪 Testing ##

All automated tests pass.  I deployed a staging AMI with these changes and verified that it configured the Crowdstrike Falcon sensor as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert to the default branch of [cisagov/freeipa-server-tf-module](https://github.com/cisagov/freeipa-server-tf-module) once cisagov/freeipa-server-tf-module#80 has been merged.